### PR TITLE
Inclusão de templates para a escrita das issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+- **Tipo de implementação**: (refatoração/feature nova) 
+- **Dependências**:
+
+## Descrição:
+
+Aqui você irá descrever o cenário identificado e todo o contexto envolvido. Pode-se
+incluir workflows, imagens e o que julgar necessário para demonstrar e clarificar
+a o problema a ser resolvido e/ou melhoria a ser feita.
+
+
+## Proposta:
+
+Aqui você irá descrever a sua proposta (caso a tenha) de implementação para o
+cenário apresentado acima. Pode ser um texto, uma lista de passos ou mesmo um
+*sample* de código. A proposta deve ser clara e atender a todos os requisitos do
+cenário apresentado.

--- a/ISSUE_TEMPLATE/bug.md
+++ b/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,15 @@
+- **Versão do pacote**: #.#.#
+- **Versão do PHP**:
+
+## Descrição:
+
+Aqui você irá descrever o problema identificado da melhor maneira que puder, com 
+qualquer informação que julgue necessária para se entender a situação (incluindo 
+mensagens de erro e log).
+
+
+## Steps to Reproduce:
+
+Aqui você irá lista os passos necessários para reproduzir a situação descrita 
+anteriormente. Essa informação será importante para ajudar outros a testar o 
+problema nas mesmas condições que você.

--- a/ISSUE_TEMPLATE/bug.md
+++ b/ISSUE_TEMPLATE/bug.md
@@ -8,7 +8,7 @@ qualquer informação que julgue necessária para se entender a situação (incl
 mensagens de erro e log).
 
 
-## Steps to Reproduce:
+## Reproduzir situação:
 
 Aqui você irá lista os passos necessários para reproduzir a situação descrita 
 anteriormente. Essa informação será importante para ajudar outros a testar o 

--- a/ISSUE_TEMPLATE/feat.md
+++ b/ISSUE_TEMPLATE/feat.md
@@ -1,0 +1,16 @@
+- **Tipo de implementação**: (refatoração/feature nova) 
+- **Dependências**:
+
+## Descrição:
+
+Aqui você irá descrever o cenário identificado e todo o contexto envolvido. Pode-se
+incluir workflows, imagens e o que julgar necessário para demonstrar e clarificar
+a o problema a ser resolvido e/ou melhoria a ser feita.
+
+
+## Proposta:
+
+Aqui você irá descrever a sua proposta (caso a tenha) de implementação para o
+cenário apresentado acima. Pode ser um texto, uma lista de passos ou mesmo um
+*sample* de código. A proposta deve ser clara e atender a todos os requisitos do
+cenário apresentado.


### PR DESCRIPTION
Afim de padronizar a escrita e facilitar a identificação das informações na issues, este pull request propõe a inclusão de templates para a escrita das issues. Dessa forma, ao se criar uma issue, o autor receberá uma sugestão de estrutura que ajudará os mantenedores a entender o que está sendo proposto ou reportado.

Dois templates foram criados, para implementações e para reporte de bugs. O primeiro foi configurado como o template default, uma vez que a implementação do pacote ainda não começou e não existe uma release disponível para download. Quando a primeira release for publicada, o ideal é que o template de bugs seja colocado como default e caso o autor sinta a necessidade, ele carregue outro template para a issue.